### PR TITLE
Update to latest primitive types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ evm-gasometer = { version = "0.15", path = "gasometer", default-features = false
 evm-runtime = { version = "0.15", path = "runtime", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 rlp = { version = "0.4", default-features = false }
-primitive-types = { version = "0.6", default-features = false, features = ["rlp"] }
+primitive-types = { version = "0.7", default-features = false, features = ["rlp"] }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [features]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
-primitive-types = { version = "0.6", default-features = false }
+primitive-types = { version = "0.7", default-features = false }
 
 [dev-dependencies]
 hex = "0.4"

--- a/gasometer/Cargo.toml
+++ b/gasometer/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
-primitive-types = { version = "0.6", default-features = false }
+primitive-types = { version = "0.7", default-features = false }
 evm-core = { version = "0.15", path = "../core", default-features = false }
 evm-runtime = { version = "0.15", path = "../runtime", default-features = false }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 evm-core = { version = "0.15", path = "../core", default-features = false }
-primitive-types = { version = "0.6", default-features = false }
+primitive-types = { version = "0.7", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 
 [features]


### PR DESCRIPTION
A new 0.x version of primitive types has been published a few days ago – and we'd like to use them in substrate. Unfortunately this also means the evm-module needs an update or there is a version mismatch.

I suppose this is a breaking change as these types are part of the external API.